### PR TITLE
BEP-0001 - populationAbundance function

### DIFF
--- a/docs/drafts/BEP-0001.md
+++ b/docs/drafts/BEP-0001.md
@@ -41,10 +41,9 @@ Adding a populationAbundance() function would allow capturing population level c
  
 ## Discussion
 
-* Should we use this for cell populations as well? E.g., "T-helper 17 cell"?
+* Should we use this for cell populations as well? E.g., (PMID 19404966) "The number of Th17 cells increased during SLE flare". Is there a need for distinct entity types for populations of cells and taxonomic groups, i.e., different needs for modifying functions?
 * Similar to other BEL abundance types, should the loc() modifier apply? E.g., pop(TAX:"Demodex folliculorum", loc(UBERON:"hair follicle"))
-* Almost all other BEL abundance types can participate in complexes. Should pop() participate in complexes? Or do we need a new entity or relationship to represent physical interactions between populations and/or populations and other abundances?
-* How should symbiotic or parasitic relationships be represented?
+* Almost all other BEL abundance types can participate in complexes. Should pop() participate in complexes? Or do we need a new entity or relationship to represent physical interactions between populations and/or populations and other abundances?How should symbiotic or parasitic relationships be represented?
 
 ## Specification
 

--- a/docs/drafts/BEP-0001.md
+++ b/docs/drafts/BEP-0001.md
@@ -2,9 +2,9 @@
 
 ## Abstract
 
-The purpose of this BEP is to add populationAbundance(TAX:<species_id>) or pop(TAX:<species_id>) to the BEL Language. 
+The purpose of this BEP is to add populationAbundance(TAX:<taxon_id>) or pop(TAX:<taxon_id>) to the BEL Language. 
 
-A populationAbundance function would allow biologists and toxicologists to capture population changes in species. There is currently no way to capture this information using BEL 2.0.0. This would be especially useful in microbiome work.
+A populationAbundance function would allow biologists and toxicologists to capture population changes in a taxon, e.g., a species, subspecies, or phylum. There is currently no way to capture this information using BEL 2.0.0. This would be especially useful in microbiome work.
 
 ## Preamble
 
@@ -41,14 +41,17 @@ Adding a populationAbundance() function would allow capturing population level c
  
 ## Discussion
 
-* Should we use this for cell populations as well?
+* Should we use this for cell populations as well? E.g., "T-helper 17 cell"?
+* Similar to other BEL abundance types, should the loc() modifier apply? E.g., pop(TAX:"Demodex folliculorum", loc(UBERON:"hair follicle"))
+* Almost all other BEL abundance types can participate in complexes. Should pop() participate in complexes? Or do we need a new entity or relationship to represent physical interactions between populations and/or populations and other abundances?
+* How should symbiotic or parasitic relationships be represented?
 
 ## Specification
 
 The new language feature is:
 
-  populationAbundance(<Species>)
-  pop(<Species>)
+  populationAbundance(<Taxon>)
+  pop(<Taxon>)
   
   Species is currently supported by the BEL.bio API using the NCBI Taxonomy (TAX) namespace.
 
@@ -67,7 +70,7 @@ The reference implementation will target the next minor point release of the BEL
           abbreviation: pop
           categories:
           - abundance
-          description: Denotes the abundance of a species.     
+          description: Denotes the abundance of a taxon.     
           name: populationAbundance
       signatures:
         populationAbundance:


### PR DESCRIPTION
Generalized 'species' to 'taxon' to make it clear that pop() should also apply to taxonomic groupings that are broader or narrower than species.
Expanded discussion.