### PR TITLE
BEP-0006 - Gene Modifications

### DIFF
--- a/docs/drafts/BEP-0006.md
+++ b/docs/drafts/BEP-0006.md
@@ -1,0 +1,61 @@
+# Add Gene Modification Syntax
+
+## Abstract
+
+This BEP adds gene modification syntax (`geneModification`/`gmod`) that supports encoding modifications
+to genes with similar syntax/semantics as protein modifications.
+
+## Preamble
+
+BEP-Id: BEP-0006
+
+Status: Draft
+
+Version: 1
+
+BEL-Version: 2.0.0+
+
+Authors: Charles Tapley Hoyt (charles.hoyt@scai.fraunhofer.de)
+
+Created-Date: 2018-07-17
+
+Type: Standards Track
+
+## Rationale and Goals
+
+The current BEL specification does not allow for encoding modifications to genes, which may have impact that would be nicely captured in BEL. Among the modifications that are targeted by this BEP are the methylation and acetylation of genes, but other types of modifications might also be appropriate.
+
+While it relied on the non-strict parsing from the BEL Framework and did not provide a specification, some ideas from this BEP can be attributed to: Khanam Irin, A., Kodamullil, A. T., Gündel, M., & Hofmann-Apitius, M. (2015). [Computational Modelling Approaches on Epigenetic Factors in Neurodegenerative and Autoimmune Diseases and Their Mechanistic Analysis](https://doi.org/10.1155/2015/737168). Journal of Immunology Research, 2015, 737168. 
+
+## Use Cases
+
+Adding the `geneModification`/`gmod` would allow capturing the effects on several levels from gene modifications.
+
+```
+SET Citation = {"PubMed", "17948130"}
+SET Evidence = "the methylation of NDUFB6 was found to be negatively correlated with its expression in a study of insulin resistance and Type II diabetes"
+
+SET Disease = "Type II diabetes"
+
+g(HGNC:NDUFB6, gmod(Me)) negativeCorrelation r(HGNC:NDUFB6)
+````
+
+## Discussion
+
+- What other types of gene modifications might be nice to represent? What about histone proteins?
+- Should further syntax for specifying the position be added to mirror `pmod()`? For people interested in generating BEL from resources like ENCODE, this might be useful.
+
+## Specification
+
+The `geneModification`/`gmod` function takes a single namespace argument corresponding to the modification:
+
+`gmod(<nsarg>)`
+
+Reasonable arguments:
+
+- From the BEL standard namespace, `M`, `Me`, and `methylation`all refer to methylation on the given gene.
+- Descendants of the Gene Ontology entry, GO_0006304: "DNA modification", are also appropriate.
+
+## Backwards Compatibility
+
+This proposed feature is for 2.0.0+ and will be added to the language so does not require any efforts to migrate older BEL knowledge.

--- a/docs/drafts/BEP-0006.md
+++ b/docs/drafts/BEP-0006.md
@@ -49,12 +49,21 @@ g(HGNC:NDUFB6, gmod(Me)) negativeCorrelation r(HGNC:NDUFB6)
 
 The `geneModification`/`gmod` function takes a single namespace argument corresponding to the modification:
 
-`gmod(<nsarg>)`
+`gmod(ns:v)`
 
 Reasonable arguments:
 
 - From the BEL standard namespace, `M`, `Me`, and `methylation`all refer to methylation on the given gene.
 - Descendants of the Gene Ontology entry, GO_0006304: "DNA modification", are also appropriate.
+
+This will also modify the semantics of the `geneAbundance()`/`g()` function to go from having a specification of:
+
+`geneAbundance(ns:v)` 
+
+to have 0 or more `gmod()` modifications.
+
+`geneAbundance(ns:v [, gmod(ns:v]*)` 
+
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
This BEP proposes an addition to the BEL 2.0+ syntax to support gene modifications (`gmod()`)

The full text can be found at: https://github.com/belbio/bep/blob/bep-0006/docs/drafts/BEP-0006.md