### PR TITLE
BEP-0010 - Updated BEL Relationships

### DIFF
--- a/docs/drafts/bep-0010.md
+++ b/docs/drafts/bep-0010.md
@@ -19,7 +19,7 @@ BEL-Version: 2.0.0+
 
 Authors: Charles Tapley Hoyt (@cthoyt)
 
-Created-Date: 2019-08-01
+Created-Date: 2019-08-05
 
 Type: Standards Track
 

--- a/docs/drafts/bep-0010.md
+++ b/docs/drafts/bep-0010.md
@@ -1,11 +1,19 @@
-# partOf Relationship
+# Updated BEL Relationships
 
 ## Abstract
 
 This BEP introduces the `partOf` relationship to the BEL language that mirrors the relationship by the same name in the [Gene Ontology](http://geneontology.org/docs/ontology-relations/) and many other biomedical ontologies. 
 
-This relationship replaces the `subProcessOf` relationship in the case of one biological process being a subprocess (part of) another biological process.
-This relationship also replaces the `hasComponent` relationship that connects complexes to their members, noting that the relationship is the opposite direction.
+This BEP deprecates the `subProcessOf`, `hasComponent`, and `hasComponents` relationships.
+
+This `partOf` relationship will replace the `subProcessOf` relationship in the case of one biological process being a subprocess (part of) another biological process.
+This `partOf` relationship will replace the `hasComponent` relationship that connects complexes to their members, noting that the relationship is the opposite direction.
+
+This BEP deprecates the `hasMember` and `hasMembers` relationships.
+
+The `isA` relationship will replace the `hasMember` relationship in the case of a protein being a member of a protein family.
+
+The deprecatated relationships `subProcessOf`, `hasComponent`, `hasComponents`, `hasMember`, and `hasMembers` will be removed in the next backwards-incompatible release of the BEL language (3.0.0+)
 
 ## Preamble
 
@@ -25,51 +33,25 @@ Type: Standards Track
 
 ## Rationale and Goals
 
-The goal of introducing the `partOf` relationship is to allow more information to be stored in BEL for later reasoning in teh same way that it is stored in the [Gene Ontology](http://geneontology.org/docs/ontology-relations/) and many other biomedical ontologies.
+The goal of introducing the `partOf` relationship is to allow more information to be stored in BEL for later reasoning in the same way that it is stored in the [Gene Ontology](http://geneontology.org/docs/ontology-relations/) and many other biomedical ontologies.
+A parellel goal is reduce the complexity of the BEL language while maintaining its expressability.
 
 Similarly to GO, the `partOf` relation is used to represent part-whole relations.
 Where GO necessitates that for `A partOf B` that all A's are part of a B, this is not always true in BEL, such as in the case that describes proteins participating in complexes.
 
-This BEP also deprecates the usage of the ``subProcessOf`` relationship in favor of the usage of the ``partOf`` relationship between two biological processes. Similarly, this BEP deprecates the usage of the ``hasComponent`` relationship that connects proteins and other abundances to complexes and composites in favor of using the ``partOf`` relationship, keeping in mind that the relationship has the inverse meaning (``A hasComponent B`` is the same as ``B partOf A``). Such a change does not perclude downstream consumers of BEL from adding the reciporacal relationships for algorithms such as graph traversals.
+This BEP deprecates the usage of the ``subProcessOf`` relationship in favor of the usage of the ``partOf`` relationship between two biological processes.
 
-### Reasoning over *part of*
+This BEP deprecates the usage of the ``hasComponent`` relationship that connects proteins and other abundances to complexes and composites in favor of using the ``partOf`` relationship, keeping in mind that the relationship has the inverse meaning (``A hasComponent B`` is the same as ``B partOf A``). The related ``hasComponents`` relationship is deprecated for removal in the next backwards-incompatible BEL language version without the introduction of a similar relationship with the opposite directionality.
 
-Basically, any direct paths containing only `partOf` and `isA` imply `partOf`.
+This BEP deprecates the usage of ``hasMember`` relationship in favor of the usage of the ``isA`` relationship between a protein and its family, keeping in mind that the relationship has the inverse meaning (``A hasMember B`` is the same as ``B isA A``). The ``hasMembers`` relationship is also reprecated for removal in the next backwards-incompatible BEL language version.
 
-#### `A partOf B` and `B isA C` implies `A partOf C`
+### Notes
 
-For proteins, this would describe a hierarchy of complexes. 
+These changes do not perclude downstream consumers of BEL from adding the reciporacal relationships for algorithms such as graph traversals.
 
-```
-p(X) partOf complex(Y)
-complex(Y) isA complex(Z)
+While this detail is currently left to the implementation, it is recommended that `compositeAbundance()` functions are connected to their list of members via ``partOf`` relationships.
 
-# Infer:
-p(X) partOf complex(Z)
-```
-
-#### `A partOf B` and `B partOf C` implies `A partOf C`
-
-For proteins, this would describe a complex formed of other complexes.
-
-```
-p(X) partOf complex(Y)
-complex(Y) partOf complex(Z)
-
-# Infer:
-p(X) partOf complex(Z)
-```
-
-#### `A isA B` and `B partOf C` implies `A partOf C`
-```
-p(HGNC:PRKAA1) isA p(FPLX:AMPK_alpha)
-p(HGNC:PRKAA2) isA p(FPLX:AMPK_alpha)
-p(FPLX:AMPK_alpha) partOf p(FPLX:AMPK)
-
-# Infer:
-p(HGNC:PRKAA1) partOf p(FPLX:AMPK)
-p(HGNC:PRKAA2) partOf p(FPLX:AMPK)
-````
+There are currently no explicit constraints on the types of the subjects and objects of either the ``partOf`` or ``isA`` relationships. This will be addressed by a future BEP.
 
 ## Use Cases
 
@@ -115,7 +97,6 @@ p(INTERPRO:"DAPIN domain") partOf p(INTERPRO:"NACHT-associated domain")
 
 ## Discussion
 
-
 - @whayes I'm thinking I'd like to remove the computed edges from the Specification and instead add that as a guidance on approaches for dealing with computed edges. I'm currently re-working computed edges in BELbio and all of the computed relations start with has* I'm trying to reduce expansion of edges in the graph database by not putting in both directions for every reversible edge - not sure if that is a strategy that will survive long term.
 - @ncatlett I don't think we need to include both directions for a relationship/edge in the BEL language, but it is needed for graph traversal. I don't have a strong opinion for which direction we include in the language specification, only a preference for consistency.
 
@@ -126,10 +107,47 @@ The equivalence relation will be used as any other predicate, where any BEL term
 
 `<BEL term 1> partOf <BEL term 2>`
 	
-This relationship is not two ways.
+This relationship is asymmetric, meaning that `<BEL term 1> partOf <BEL term 2>` is not the same as `<BEL term 2> partOf <BEL term 1>`. This relationship is also transitive with `partOf` (itself) and the `isA` relationship using similar rules as described in GO as outlined below.
+
+### `A partOf B` and `B isA C` implies `A partOf C`
+
+For proteins, this would describe a hierarchy of complexes. 
+
+```
+p(X) partOf complex(Y)
+complex(Y) isA complex(Z)
+
+# Infer:
+p(X) partOf complex(Z)
+```
+
+### `A partOf B` and `B partOf C` implies `A partOf C`
+
+For proteins, this would describe a complex formed of other complexes.
+
+```
+p(X) partOf complex(Y)
+complex(Y) partOf complex(Z)
+
+# Infer:
+p(X) partOf complex(Z)
+```
+
+### `A isA B` and `B partOf C` implies `A partOf C`
+```
+p(HGNC:PRKAA1) isA p(FPLX:AMPK_alpha)
+p(HGNC:PRKAA2) isA p(FPLX:AMPK_alpha)
+p(FPLX:AMPK_alpha) partOf p(FPLX:AMPK)
+
+# Infer:
+p(HGNC:PRKAA1) partOf p(FPLX:AMPK)
+p(HGNC:PRKAA2) partOf p(FPLX:AMPK)
+````
+
+This does not conflict with the fact that `p(HGNC:PRKAA1)` and `p(HGNC:PRKAA2)` won't be in the same instance of an `p(FPLX:AMPK)` complex.
 
 ## Backwards Compatibility
 
-This BEP is backwards compatible. Compilers for BEL 1.0, 2.0, and 2.1 can automatically upgrade statements that are deprecated without the inclusion of additional information.
+This BEP is backwards compatible. Compilers for BEL 1.0, 2.0, and 2.1 can automatically upgrade statements that are deprecated without the inclusion of additional information. However, this BEP introduces deprecations for several relationships that will be removed in the next major revision to the BEL language (3.0+). Before that, implementations of the BEL language can automatically upgrade these deprecated statements as described above.
 
 ## Reference Implementation

--- a/docs/drafts/bep-0010.md
+++ b/docs/drafts/bep-0010.md
@@ -1,0 +1,135 @@
+# partOf Relationship
+
+## Abstract
+
+This BEP introduces the `partOf` relationship to the BEL language that mirrors the relationship by the same name in the [Gene Ontology](http://geneontology.org/docs/ontology-relations/) and many other biomedical ontologies. 
+
+This relationship replaces the `subProcessOf` relationship in the case of one biological process being a subprocess (part of) another biological process.
+This relationship also replaces the `hasComponent` relationship that connects complexes to their members, noting that the relationship is the opposite direction.
+
+## Preamble
+
+BEP-Id: BEP-0010
+
+Status: Draft
+
+Version: 1
+
+BEL-Version: 2.0.0+
+
+Authors: Charles Tapley Hoyt (@cthoyt)
+
+Created-Date: 2019-08-01
+
+Type: Standards Track
+
+## Rationale and Goals
+
+The goal of introducing the `partOf` relationship is to allow more information to be stored in BEL for later reasoning in teh same way that it is stored in the [Gene Ontology](http://geneontology.org/docs/ontology-relations/) and many other biomedical ontologies.
+
+Similarly to GO, the `partOf` relation is used to represent part-whole relations.
+Where GO necessitates that for `A partOf B` that all A's are part of a B, this is not always true in BEL, such as in the case that describes proteins participating in complexes.
+
+This BEP also deprecates the usage of the ``subProcessOf`` relationship in favor of the usage of the ``partOf`` relationship between two biological processes. Similarly, this BEP deprecates the usage of the ``hasComponent`` relationship that connects proteins and other abundances to complexes and composites in favor of using the ``partOf`` relationship, keeping in mind that the relationship has the inverse meaning (``A hasComponent B`` is the same as ``B partOf A``). Such a change does not perclude downstream consumers of BEL from adding the reciporacal relationships for algorithms such as graph traversals.
+
+### Reasoning over *part of*
+
+Basically, any direct paths containing only `partOf` and `isA` imply `partOf`.
+
+#### `A partOf B` and `B isA C` implies `A partOf C`
+
+For proteins, this would describe a hierarchy of complexes. 
+
+```
+p(X) partOf complex(Y)
+complex(Y) isA complex(Z)
+
+# Infer:
+p(X) partOf complex(Z)
+```
+
+#### `A partOf B` and `B partOf C` implies `A partOf C`
+
+For proteins, this would describe a complex formed of other complexes.
+
+```
+p(X) partOf complex(Y)
+complex(Y) partOf complex(Z)
+
+# Infer:
+p(X) partOf complex(Z)
+```
+
+#### `A isA B` and `B partOf C` implies `A partOf C`
+```
+p(HGNC:PRKAA1) isA p(FPLX:AMPK_alpha)
+p(HGNC:PRKAA2) isA p(FPLX:AMPK_alpha)
+p(FPLX:AMPK_alpha) partOf p(FPLX:AMPK)
+
+# Infer:
+p(HGNC:PRKAA1) partOf p(FPLX:AMPK)
+p(HGNC:PRKAA2) partOf p(FPLX:AMPK)
+````
+
+## Use Cases
+
+### `partOf` as a drop-in replacement for `subProcessOf`
+
+A biological process is a subprocess of another (note these examples use OBO-style syntax from BEP-0008)
+
+```
+bp(GO:0006915 ! "apoptotic process") partOf bp(GO:0012501 ! "programmed cell death")
+````
+
+### `partOf` as an inverse replacement of `hasComponent`
+
+In BEL 1.0/2.0, the definition of the 911 complex would have been written with:
+
+```
+complex(FPLX:9_1_1) hasComponent p(HGNC:HUS1)
+complex(FPLX:9_1_1) hasComponent p(HGNC:RAD1)
+complex(FPLX:9_1_1) hasComponent p(HGNC:RAD9A)
+```
+
+To unify the relationships with FamPlex itself, it can now be written as:
+
+```
+p(HGNC:HUS1)  partOf complex(FPLX:9_1_1)
+p(HGNC:RAD1)  partOf complex(FPLX:9_1_1)
+p(HGNC:RAD9A) partOf complex(FPLX:9_1_1) 
+```
+
+### `partOf` in annotation of protein domains
+
+The existence of a domain within a protein can be described like in the following:
+
+```
+p(INTERPRO:"Death domain") partOf p(HGNC:DAPK1)
+```
+
+The hierarchy of protein domains can be described like in the following:
+
+```
+p(INTERPRO:"DAPIN domain") partOf p(INTERPRO:"NACHT-associated domain")
+```
+
+## Discussion
+
+
+- @whayes I'm thinking I'd like to remove the computed edges from the Specification and instead add that as a guidance on approaches for dealing with computed edges. I'm currently re-working computed edges in BELbio and all of the computed relations start with has* I'm trying to reduce expansion of edges in the graph database by not putting in both directions for every reversible edge - not sure if that is a strategy that will survive long term.
+- @ncatlett I don't think we need to include both directions for a relationship/edge in the BEL language, but it is needed for graph traversal. I don't have a strong opinion for which direction we include in the language specification, only a preference for consistency.
+
+
+## Specification
+
+The equivalence relation will be used as any other predicate, where any BEL term can be used as the subject and object.
+
+`<BEL term 1> partOf <BEL term 2>`
+	
+This relationship is not two ways.
+
+## Backwards Compatibility
+
+This BEP is backwards compatible. Compilers for BEL 1.0, 2.0, and 2.1 can automatically upgrade statements that are deprecated without the inclusion of additional information.
+
+## Reference Implementation

--- a/docs/published/BEP-0010.md
+++ b/docs/published/BEP-0010.md
@@ -19,7 +19,7 @@ The deprecatated relationships `subProcessOf`, `hasComponent`, `hasComponents`, 
 
 BEP-Id: BEP-0010
 
-Status: Draft
+Status: Published
 
 Version: 1
 


### PR DESCRIPTION
This BEP introduces the `partOf` relationship, similar to that found in the Gene Ontology and other biomedical ontologies. It also deprecates the `subProcessOf` and `hasComponent` relationships in favor of using the `partOf` relationship.

The full text of this BEP can be found at https://github.com/belbio/bep/blob/add-bep-0010-part-of/docs/drafts/bep-0010.md