### PR TITLE
 BEP-0011 - Add binds relation

### DIFF
--- a/docs/published/BEP-0011.md
+++ b/docs/published/BEP-0011.md
@@ -1,0 +1,66 @@
+# Add new relation: binds
+
+## Abstract
+
+This BEP adds the "binds" relationship between two physical entities. 
+
+## Preamble
+
+BEP-Id: BEP-0011
+
+Status: Draft
+
+Version: 1
+
+BEL-Version: 2.0.0  (which version(s) of BEL are to be changed by this BEP)
+
+Authors: Charles Tapley Hoyt ([https://github.com/cthoyt](@cthoyt))
+
+Created-Date: 2020-02-09
+
+Type: Standards Track
+
+## Rationale and Goals
+
+While the `complex()` function allows either the reference to a named complex or
+the definition of an ad-hoc complex, not all proteins in a complex
+physically interact with each other.
+
+The `binds` relationship will allow for more explicit definition of which
+proteins physically interact with each other. For example, a protein complex
+`complex(A, B, C)` may be arranged linearly such that `A binds B` and
+`B binds C`, but `A` does not bind `C`. Another complex `complex(X, Y, Z)`
+may be arranged in a triangle such that `A binds B`, `B binds C`, and
+`C binds A`.
+
+## Use Cases
+
+The `binds` relationship will be the prefered binary relationship for
+protein-protein relationships, such as the physical interactions from
+the [HIPPIE](http://cbdm-01.zdv.uni-mainz.de/~mschaefer/hippie/) database.
+
+```
+p(UNIPROT:P42858 ! HD_HUMAN) binds p(UNIPROT:P54257 ! HAP1_HUMAN) 
+```
+
+See http://cbdm-01.zdv.uni-mainz.de/~mschaefer/hippie/query.php?s=HD_HUMAN
+for more information on this interaction.
+
+## Discussion
+
+- Is `binds` the best name? Maybe `interacts` is better, but that's a bit
+  more general and doesn't necessarily suggest *physical* binding
+
+## Specification
+
+This BEP adds a `binds` relationship to BEL.
+
+`binds` is non-directional, such that `A binds B` is equivalent to `B binds A`.
+
+## Backwards Compatibility
+
+All BEPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The BEP must explain how the author proposes to deal with these incompatibilities. BEP submissions without a sufficient backwards compatibility treatise may be rejected outright.
+
+## Reference Implementation
+
+The reference implementation must be completed before any BEP is given status "Final", but it need not be completed before the BEP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of BEL Language and API details.


### PR DESCRIPTION
This BEP proposes an addition to the BEL 2.0+ syntax to add the `binds` relationship

The full text can be found at: https://github.com/belbio/bep/blob/add-bep-0011-binds-relation/docs/published/BEP-0011.md