### PR TITLE
BEP-0012 - Add correlation relation

### DIFF
--- a/docs/published/BEP-0012.md
+++ b/docs/published/BEP-0012.md
@@ -1,0 +1,53 @@
+# Add new relationship: correlation
+
+## Abstract
+
+BEL currently has the polar relationships `positiveCorrelation` and `negativeCorrelation`
+as well as the negative edge `noCorrelation`. Because it currently lacks an apolar relation
+for correlations, this BEP adds the `correlation`/`cor` relationship.
+
+## Preamble
+
+BEP-Id: BEP-0012
+
+Status: Draft
+
+Version: 1
+
+BEL-Version: 2.0.0  (which version(s) of BEL are to be changed by this BEP)
+
+Authors: Charles Tapley Hoyt ([https://github.com/cthoyt](@cthoyt))
+
+Created-Date: 2020-02-09
+
+Type: Standards Track
+
+## Rationale and Goals
+
+BEL currently has the polar relationships `positiveCorrelation` and `negativeCorrelation`
+as well as the negative edge `noCorrelation`. Because it currently lacks an apolar relation
+for correlations, this BEP adds the `correlation`/`cor` relationship. This would be
+appropriate for situations where a correlation has been stated, but without directionality.
+
+## Use Cases
+
+Gene co-expression networks often remove the directionality of the correlation between
+RNA abundances. A use case might be:
+
+```
+r(X) correlation r(Y)
+```
+
+## Discussion
+
+## Specification
+
+The technical specification should describe the syntax and semantics of any new language feature.
+
+## Backwards Compatibility
+
+All BEPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The BEP must explain how the author proposes to deal with these incompatibilities. BEP submissions without a sufficient backwards compatibility treatise may be rejected outright.
+
+## Reference Implementation
+
+The reference implementation must be completed before any BEP is given status "Final", but it need not be completed before the BEP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of BEL Language and API details.


### PR DESCRIPTION
This BEP proposes an addition to the BEL 2.0+ syntax to add the `correlation`/`cor` relationship

The full text can be found at: https://github.com/belbio/bep/blob/add-bep-0012-add-correlation/docs/published/BEP-0012.md